### PR TITLE
Separate pages and sidebar navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
     <meta charset="UTF-8">
-    <title>Codex Lab - Главная</title>
+    <title>О нас - Codex Lab</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -12,12 +12,8 @@
         <a href="contact.html">Контакты</a>
     </nav>
     <main class="main">
-        <h1>Добро пожаловать в Codex Lab!</h1>
-        <div class="tiles">
-            <div class="tile">Плитка 1</div>
-            <div class="tile">Плитка 2</div>
-            <div class="tile">Плитка 3</div>
-        </div>
+        <h1>О нас</h1>
+        <p>Мы создаем интересные проекты и делимся знаниями.</p>
     </main>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
     <meta charset="UTF-8">
-    <title>Codex Lab - Главная</title>
+    <title>Контакты - Codex Lab</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -12,12 +12,8 @@
         <a href="contact.html">Контакты</a>
     </nav>
     <main class="main">
-        <h1>Добро пожаловать в Codex Lab!</h1>
-        <div class="tiles">
-            <div class="tile">Плитка 1</div>
-            <div class="tile">Плитка 2</div>
-            <div class="tile">Плитка 3</div>
-        </div>
+        <h1>Контакты</h1>
+        <p>Свяжитесь с нами по электронной почте example@example.com.</p>
     </main>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -3,22 +3,46 @@ body {
     background: linear-gradient(135deg, #74ebd5 0%, #ACB6E5 100%);
     color: #333;
     margin: 0;
-    padding: 0;
     display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
+    min-height: 100vh;
 }
 
-.container {
-    text-align: center;
+.sidebar {
+    width: 200px;
     background: rgba(255, 255, 255, 0.8);
-    padding: 40px;
+    padding: 20px;
+}
+
+.sidebar a {
+    display: block;
+    color: #333;
+    text-decoration: none;
+    margin-bottom: 10px;
+}
+
+.sidebar a:hover {
+    text-decoration: underline;
+}
+
+.main {
+    flex-grow: 1;
+    padding: 20px;
+}
+
+.tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    grid-gap: 20px;
+}
+
+.tile {
+    background: rgba(255, 255, 255, 0.8);
+    padding: 20px;
     border-radius: 8px;
+    text-align: center;
     box-shadow: 0 4px 8px rgba(0,0,0,0.1);
 }
 
 h1 {
     margin-top: 0;
-    font-size: 2.5em;
 }


### PR DESCRIPTION
## Summary
- split single-page site into separate `index.html`, `about.html` and `contact.html`
- add sidebar navigation on all pages
- provide simple tile layout for the main page
- update CSS for sidebar and tiles

## Testing
- `python3 main.py`
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_b_687bd41be9b48322a54bdbd71fbd31a1