### PR TITLE
Create modern pitch-style landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,23 +1,69 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Codex Lab - Главная</title>
-    <link rel="stylesheet" href="style.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pitch Style Landing</title>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: 'Inter', sans-serif; background: #ffffff; color: #ffffff; }
+        .hero {
+            background: linear-gradient(135deg, #6e00ff 0%, #c56cf0 100%);
+            padding: 60px 40px 120px;
+            text-align: center;
+            position: relative;
+            overflow: hidden;
+        }
+        nav.main-nav { display: flex; justify-content: space-between; align-items: center; margin-bottom: 80px; }
+        nav.main-nav ul { display: flex; list-style: none; gap: 30px; }
+        nav.main-nav a { color: #ffffff; text-decoration: none; font-weight: 500; transition: opacity 0.3s; }
+        nav.main-nav a:hover { opacity: 0.8; }
+        nav.main-nav .actions { display: flex; gap: 20px; }
+        h1 { font-size: 3rem; margin-bottom: 20px; }
+        .subtitle { font-size: 1.25rem; opacity: 0.9; margin-bottom: 40px; }
+        .cta { display: flex; gap: 20px; justify-content: center; margin-bottom: 40px; }
+        .btn { padding: 14px 28px; border-radius: 25px; font-weight: 600; font-size: 1rem; cursor: pointer; transition: box-shadow 0.3s, background 0.3s, color 0.3s; text-decoration: none; }
+        .btn-primary { background: #ffffff; color: #6e00ff; border: none; }
+        .btn-primary:hover { box-shadow: 0 4px 12px rgba(0,0,0,0.2); }
+        .btn-outline { background: transparent; border: 2px solid #ffffff; color: #ffffff; }
+        .btn-outline:hover { background: rgba(255,255,255,0.1); }
+        .tabs { display: flex; gap: 20px; justify-content: center; }
+        .tabs a { padding: 10px 20px; border-radius: 20px; color: #ffffff; text-decoration: none; font-weight: 500; opacity: 0.7; transition: background 0.3s, opacity 0.3s; }
+        .tabs a.active { background: rgba(255,255,255,0.2); opacity: 1; }
+        .wave { position: absolute; bottom: 0; left: 0; width: 100%; }
+    </style>
 </head>
 <body>
-    <nav class="sidebar">
-        <a href="index.html">Главная</a>
-        <a href="about.html">О нас</a>
-        <a href="contact.html">Контакты</a>
-    </nav>
-    <main class="main">
-        <h1>Добро пожаловать в Codex Lab!</h1>
-        <div class="tiles">
-            <div class="tile">Плитка 1</div>
-            <div class="tile">Плитка 2</div>
-            <div class="tile">Плитка 3</div>
+    <div class="hero">
+        <nav class="main-nav">
+            <ul>
+                <li><a href="#">Product</a></li>
+                <li><a href="#">Use Cases</a></li>
+                <li><a href="#">Templates</a></li>
+                <li><a href="#">Resources</a></li>
+                <li><a href="#">Pricing</a></li>
+            </ul>
+            <div class="actions">
+                <a href="#" class="btn btn-outline" style="padding:8px 20px;">Log in</a>
+                <a href="#" class="btn btn-primary" style="padding:8px 20px;">Sign up</a>
+            </div>
+        </nav>
+        <h1>Win more deals. Pitch.</h1>
+        <p class="subtitle">The fastest way to create and share stunning presentations.</p>
+        <div class="cta">
+            <a href="#" class="btn btn-primary">Sign up for free</a>
+            <a href="#" class="btn btn-outline">Get a demo</a>
         </div>
-    </main>
+        <div class="tabs">
+            <a href="#" class="active">Pitch</a>
+            <a href="#">Design</a>
+            <a href="#">Collaborate</a>
+            <a href="#">Analyze</a>
+        </div>
+        <svg class="wave" viewBox="0 0 1440 320" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+            <path fill="#ffffff" d="M0,288L48,288C96,288,192,288,288,266.7C384,245,480,203,576,176C672,149,768,139,864,154.7C960,171,1056,213,1152,213.3C1248,213,1344,171,1392,149.3L1440,128V320H1392C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320H0Z"></path>
+        </svg>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- overhaul `index.html` into a single-page pitch-style site with gradient hero, tabs, navigation, and buttons
- inline all styles and add a decorative wave edge

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_b_687bd985ab3c83228fd49a202fc22b2a